### PR TITLE
Add option for static lib prefix/suffix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,14 @@ dep_args = []
 if buildlib
 	libtype = get_option('default_library')
 
+	static_prefix = []
+	static_suffix = []
+
+	if get_option('static_lib_suffix')
+		static_prefix = ''
+		static_suffix = 'lib'
+	endif
+
 	# TODO: temporary workaround, see https://github.com/mesonbuild/meson/issues/3304
 	# The problem is that on windows, function symbols must be declared
 	# differently when building a static library.
@@ -77,6 +85,8 @@ if buildlib
 			c_args: static_args + common_args + dep_args,
 			dependencies: dep_threads,
 			install: true,
+			name_prefix: static_prefix,
+			name_suffix: static_suffix,
 			include_directories: inc)
 
 		# when both library types are built, the declared dependency
@@ -87,12 +97,17 @@ if buildlib
 			'used by default for dependency and pkgconfig file')
 		libs += [shared_lib]
 	else
+		prefix = []
+		suffix = []
+
 		if libtype == 'shared'
 			if host_machine.system() == 'windows'
 				dlg_args += '-DDLG_API=__declspec(dllexport)'
 			endif
 		elif libtype == 'static'
 			dep_args += '-DDLG_STATIC'
+			prefix = static_prefix
+			suffix = static_suffix
 		else
 			error('Unknown default_library type')
 		endif
@@ -101,6 +116,8 @@ if buildlib
 			'src/dlg/dlg.c',
 			c_args: dlg_args + common_args + dep_args,
 			dependencies: dep_threads,
+			name_prefix: prefix,
+			name_suffix: suffix,
 			install: true,
 			include_directories: inc)
 	endif

--- a/meson.build
+++ b/meson.build
@@ -53,26 +53,20 @@ dep_threads = dependency('threads')
 dep_args = []
 
 if buildlib
-	libtype = get_option('default_library')
-
-	static_prefix = []
-	static_suffix = []
-
-	if get_option('static_lib_suffix')
-		static_prefix = ''
-		static_suffix = 'lib'
-	endif
-
 	# TODO: temporary workaround, see https://github.com/mesonbuild/meson/issues/3304
 	# The problem is that on windows, function symbols must be declared
 	# differently when building a static library.
-	if libtype == 'both'
-		static_args = dlg_args + ['-DDLG_STATIC']
-		shared_args = dlg_args
-		if host_machine.system() == 'windows'
-			shared_args += ['-DDLG_API=__declspec(dllexport)']
-		endif
+	libtype = get_option('default_library')
+	build_static = libtype == 'both' or libtype == 'static'
+	build_shared = libtype == 'both' or libtype == 'shared'
 
+	static_args = dlg_args + ['-DDLG_STATIC']
+	shared_args = dlg_args
+	if host_machine.system() == 'windows'
+		shared_args += ['-DDLG_API=__declspec(dllexport)']
+	endif
+
+	if build_shared
 		shared_lib = shared_library('dlg',
 			'src/dlg/dlg.c',
 			c_args: shared_args + common_args + dep_args,
@@ -80,46 +74,32 @@ if buildlib
 			install: true,
 			include_directories: inc)
 
-		static_lib = static_library('dlg',
-			'src/dlg/dlg.c',
-			c_args: static_args + common_args + dep_args,
-			dependencies: dep_threads,
-			install: true,
-			name_prefix: static_prefix,
-			name_suffix: static_suffix,
-			include_directories: inc)
-
-		# when both library types are built, the declared dependency
-		# and generate pkgconfig file will contain the shared library,
-		# since that's the default way of linking in c.
-		# That's also why we don't add 'DLG_STATIC' to dep_args
-		message('When building both libraries, the shared one will be ' +
-			'used by default for dependency and pkgconfig file')
 		libs += [shared_lib]
-	else
-		prefix = []
-		suffix = []
+	endif
 
-		if libtype == 'shared'
-			if host_machine.system() == 'windows'
-				dlg_args += '-DDLG_API=__declspec(dllexport)'
-			endif
-		elif libtype == 'static'
-			dep_args += '-DDLG_STATIC'
-			prefix = static_prefix
-			suffix = static_suffix
+	if build_static
+		if get_option('static_msvc_libname')
+			static_lib = static_library('dlg',
+				'src/dlg/dlg.c',
+				c_args: static_args + common_args + dep_args,
+				dependencies: dep_threads,
+				install: true,
+				name_prefix: '',
+				name_suffix: '.lib',
+				include_directories: inc)
 		else
-			error('Unknown default_library type')
+			static_lib = static_library('dlg',
+				'src/dlg/dlg.c',
+				c_args: static_args + common_args + dep_args,
+				dependencies: dep_threads,
+				install: true,
+				include_directories: inc)
 		endif
 
-		libs += library('dlg',
-			'src/dlg/dlg.c',
-			c_args: dlg_args + common_args + dep_args,
-			dependencies: dep_threads,
-			name_prefix: prefix,
-			name_suffix: suffix,
-			install: true,
-			include_directories: inc)
+		if not build_shared
+			dep_args += static_args
+			libs += [static_lib]
+		endif
 	endif
 
 	pkg = import('pkgconfig')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,9 +10,15 @@ option('tests', type: 'boolean', value: false) # build the tests?
 # and not only when stdout is a tty and dlg_win_init_ansi returns true.
 option('default_output_always_color', type: 'boolean', value: false)
 
-# - Only relevant on windows -
+
+# - Only relevant/useful on windows -
 # Whether to handle the windows console correctly (in terms of color/style).
 # Allows apps to print utf-8 and use color on the windows command line.
 # When setting this to true, on wsl dlg_win_init_ansi will return false
 # since then the default handles will be files.
 option('win_console', type: 'boolean', value: true)
+
+# Whether to generate 'dlg.lib' instead of 'libdlg.a' (as is mesons default)
+# for a static library build on windows. This might be needed/useful for
+# some MSVC setups, see https://github.com/nyorain/dlg/issues/3
+option('static_lib_suffix', type: 'boolean', value: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,4 +21,4 @@ option('win_console', type: 'boolean', value: true)
 # Whether to generate 'dlg.lib' instead of 'libdlg.a' (as is mesons default)
 # for a static library build on windows. This might be needed/useful for
 # some MSVC setups, see https://github.com/nyorain/dlg/issues/3
-option('static_lib_suffix', type: 'boolean', value: false)
+option('static_msvc_libname', type: 'boolean', value: false)


### PR DESCRIPTION
See #3. @Priyeshkkumar, could you test if this works? I tested it with MSVC 2017.
To be honest though, I don't think this should be merged, as the usecase for this is *very* specific and when using dlg as a subproject but not via meson, you could also just rename the library after building.