### PR TITLE
A string to control the layout of the dlg_features in log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 old
 *.sublime*
 android_cross.txt
+compile_commands.json
+.vscode
+.clangd

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "array": "c",
+        "string_view": "c",
+        "initializer_list": "c",
+        "utility": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "files.associations": {
-        "array": "c",
-        "string_view": "c",
-        "initializer_list": "c",
-        "utility": "c"
-    }
-}

--- a/docs/tests/core.c
+++ b/docs/tests/core.c
@@ -37,6 +37,7 @@ struct {
 
 unsigned int gerror = 0;
 FILE* check_file;
+FILE* check_formatted_file;
 
 void custom_handler(const struct dlg_origin* origin, const char* string, void* data);
 
@@ -93,9 +94,11 @@ int main() {
 
 	dlg_set_handler(&custom_handler, &gdata);
 	check_file = fopen("dlg_test_output.txt", "w");
+	check_formatted_file = fopen( "dlg_test_formatted_output.txt","w" );
 	EXPECT(!dlg_is_tty(check_file));
 
-	dlg_fprintf(check_file, u8"beginning of (some utf-8: äüß) %s", "test output file\n");
+	dlg_fprintf(check_file, u8"beginning of (some utf-8: äüß) %s", "test output file with default layout of dlg_features\n");
+	dlg_fprintf(check_formatted_file, u8"beginning of (some utf-8: äüß) %s", "test output file with custom layout of dlg_features\n");
 
 	// checks
 	// logging
@@ -238,6 +241,7 @@ int main() {
 
 	// reset handler
 	fclose(check_file);
+	fclose(check_formatted_file);
 
 	dlg_set_handler(dlg_default_output, NULL);
 	gdata.fired = false;
@@ -341,6 +345,13 @@ void custom_handler(const struct dlg_origin* origin, const char* string, void* d
 		}
 	}
 
-	unsigned int features = dlg_output_tags | dlg_output_style | dlg_output_time | dlg_output_file_line;
+	unsigned int features = dlg_output_tags | dlg_output_time | dlg_output_file_line | dlg_output_newline ;
+
+
 	dlg_generic_output_stream(check_file, features, origin, string, dlg_default_output_styles);
+
+	unsigned int features_o = dlg_output_file_line | dlg_output_func | dlg_output_tags | dlg_output_newline | dlg_output_time | dlg_output_time_msecs | dlg_output_threadsafe;
+	dlg_set_layout( "[ $ tags: {%t} $ time: %s%ms file: %l func: %F]    " );
+	dlg_generic_output_stream(check_formatted_file, features_o, origin, string, dlg_default_output_styles);
+	dlg_set_default_layout();
 }

--- a/docs/tests/core.c
+++ b/docs/tests/core.c
@@ -350,8 +350,8 @@ void custom_handler(const struct dlg_origin* origin, const char* string, void* d
 
 	dlg_generic_output_stream(check_file, features, origin, string, dlg_default_output_styles);
 
-	unsigned int features_o = dlg_output_file_line | dlg_output_func | dlg_output_tags | dlg_output_newline | dlg_output_time | dlg_output_time_msecs | dlg_output_threadsafe;
-	dlg_set_layout( "[ $ tags: {%t} $ time: %s%ms file: %l func: %F]    " );
-	dlg_generic_output_stream(check_formatted_file, features_o, origin, string, dlg_default_output_styles);
-	dlg_set_default_layout();
+	// unsigned int features_o = dlg_output_file_line | dlg_output_func | dlg_output_tags | dlg_output_newline | dlg_output_time | dlg_output_time_msecs | dlg_output_threadsafe;
+	// dlg_set_layout( "[ $ tags: {%t} $ time: %s%ms file: %l func: %F]    " );
+	// dlg_generic_output_stream(check_formatted_file, features_o, origin, string, dlg_default_output_styles);
+	// dlg_set_default_layout();
 }

--- a/docs/tests/meson.build
+++ b/docs/tests/meson.build
@@ -5,6 +5,7 @@ tests = [
 	['disabledc', 'disabled.c', []],
 	['disabledcpp', 'disabled.cpp', []],
 	['threads', 'threads.cpp', [dep_threads]],
+	['outputf', 'outputf.cpp', []],
 ]
 
 foreach test : tests

--- a/docs/tests/outputf.cpp
+++ b/docs/tests/outputf.cpp
@@ -1,0 +1,45 @@
+#include <dlg/dlg.hpp>
+
+void sample() {
+	dlg_trace("This is a trace");
+	dlg_debug("This is a debug info");
+	dlg_info("This is an info");
+	dlg_warn("This is a warning");
+	dlg_error("Errors are red");
+	dlg_assertm(1 == 2, "Well, this assertion will probably {}...", "fail");
+	dlg_infot(("tag1", "tag2"), "We can tag our stuff. Can be used to filter/redirect messages");
+	dlg_asserttm(("tag3"), 3 == 2, "The same goes for asserts");
+	dlg_info("Another feature: Utf-8 printing works automatically, even for שׁǐŉďốẅś consoles");
+	dlg_fatal("This one is printed bold. For more information, read the example already");
+}
+
+int main() {
+	dlg::set_handler([&](const struct dlg_origin& origin, const char* str){
+		dlg_generic_outputf_stream(stdout, "%s%c\n", &origin, str, dlg_default_output_styles, false);
+	});
+
+	dlg_info("Using output handler 1, pretty simple");
+	dlg_info("It should just output the messages in the appropriate styles");
+	sample();
+
+	std::printf("-------------------------------------------\n");
+
+	dlg::set_handler([&](const struct dlg_origin& origin, const char* str){
+		dlg_generic_outputf_stream(stdout, "[%o %h:%m {%t} %f] %s%c\n", &origin, str, dlg_default_output_styles, false);
+	});
+
+	dlg_info("outputting pretty much all information now. Only message is styled");
+	sample();
+	std::fprintf(stdout, "Normal, non-dlg printf message. Should not be effected by style\n");
+
+	std::printf("-------------------------------------------\n");
+
+
+	dlg::set_handler([&](const struct dlg_origin& origin, const char* str){
+		dlg_generic_outputf_stream(stdout, "%s[%o %h:%m %f]%r %c %s[%t]%r\n", &origin, str, dlg_default_output_styles, false);
+	});
+
+	dlg_info("This time, only the meta information is styled");
+	sample();
+	std::fprintf(stdout, "Normal, non-dlg printf message. Should not be effected by style\n");
+}

--- a/docs/tests/threads.cpp
+++ b/docs/tests/threads.cpp
@@ -5,7 +5,7 @@
 
 // mainly used to test that everything works multithreaded and that
 // there will be no leaks
-void test() 
+void test()
 {
 	dlg_info("main");
 	dlg_info("initing thread 2");
@@ -31,7 +31,7 @@ void test()
 
 	for(auto i = 0u; i < 10; ++i) {
 		std::this_thread::sleep_for(std::chrono::nanoseconds(i * 10));
-		dlg_info("Did he said something already?");
+		dlg_info("Did he say something already?");
 	}
 
 	dlg_info("Hopefully he said something by now...");
@@ -42,11 +42,11 @@ void test()
 
 int main() {
 	// default handler (threadsafe)
-	std::cout << " =================== 1 ==================== \n";
+	std::cout << " =================== 1 (threadsafe) ==================== \n";
 	test();
 
 	// custom handler (threadsafe)
-	std::cout << " =================== 2 ==================== \n";
+	std::cout << " =================== 2 (threadsafe) ==================== \n";
 	auto tid1 = std::this_thread::get_id();
 	dlg::set_handler([&](const struct dlg_origin& origin, const char* str){
 		auto t = (std::this_thread::get_id() == tid1) ? "thread-1: " : "thread-2: ";
@@ -56,7 +56,7 @@ int main() {
 	test();
 
 	// custom handler (not threadsafe)
-	std::cout << " =================== 3 ==================== \n";
+	std::cout << " =================== 3 (not threasafe) ==================== \n";
 	dlg::set_handler([&](const struct dlg_origin& origin, const char* str){
 		unsigned int features = dlg_output_file_line | dlg_output_newline |
 			dlg_output_style;

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -240,6 +240,37 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		const char*, const char*, const char*);
 	DLG_API const char* dlg__strip_root_path(const char* file, const char* base);
 
+	// Use this function to change the layout of the dlg features in the log messages.
+	// See include/dlg/output.h for list of dlg_features.
+	// Use following conversion characters for representing the dlg features
+	// in the layout:
+	// %s  - 	dlg_output_time
+	// %ms - 	dlg_output_time_msecs 
+	// %t  - 	dlg_output_tags
+	// %F  -	dlg_output_func
+	// %l  -	dlg_output_file_line
+	//
+	// NOTE:
+	// Only the above specified conversion characters are converted to 
+	// respective dlg_features rest are written as it is. 
+	//
+	// Example: 
+	// dlg_set_features_layout("[ { %t } time: %s %l ]  ");
+	//					OR
+	// const char* format = "[ { %t } time: %s %l ]  ";
+	// dlg_set_features_layout( format );
+	//
+	// For tags: {tag1, tag2} time: 16:57:46 docs/tests/core.c:115 ]name: main() and tags: 
+	// "tag1","tag2" it will print the dlg_features in log messages like:
+	// [ tags: {tag1, tag2} time: 16:57:46 docs/tests/core.c:115 ]  log message
+	// 
+	DLG_API void dlg_set_layout( const char* layout );
+
+	// Use this function to reset the default format i.e. predefined layout
+	// which dlg uses for printing dlg_features.
+	//
+	DLG_API void dlg_set_default_layout();
+
 #endif // DLG_DISABLE
 
 // Untagged leveled logging

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -239,38 +239,6 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	DLG_API void dlg__do_log(enum dlg_level lvl, const char* const*, const char*, int,
 		const char*, const char*, const char*);
 	DLG_API const char* dlg__strip_root_path(const char* file, const char* base);
-
-	// Use this function to change the layout of the dlg features in the log messages.
-	// See include/dlg/output.h for list of dlg_features.
-	// Use following conversion characters for representing the dlg features
-	// in the layout:
-	// %s  - 	dlg_output_time
-	// %ms - 	dlg_output_time_msecs 
-	// %t  - 	dlg_output_tags
-	// %F  -	dlg_output_func
-	// %l  -	dlg_output_file_line
-	//
-	// NOTE:
-	// Only the above specified conversion characters are converted to 
-	// respective dlg_features rest are written as it is. 
-	//
-	// Example: 
-	// dlg_set_features_layout("[ { %t } time: %s %l ]  ");
-	//					OR
-	// const char* format = "[ { %t } time: %s %l ]  ";
-	// dlg_set_features_layout( format );
-	//
-	// For tags: {tag1, tag2} time: 16:57:46 docs/tests/core.c:115 ]name: main() and tags: 
-	// "tag1","tag2" it will print the dlg_features in log messages like:
-	// [ tags: {tag1, tag2} time: 16:57:46 docs/tests/core.c:115 ]  log message
-	// 
-	DLG_API void dlg_set_layout( const char* layout );
-
-	// Use this function to reset the default format i.e. predefined layout
-	// which dlg uses for printing dlg_features.
-	//
-	DLG_API void dlg_set_default_layout();
-
 #endif // DLG_DISABLE
 
 // Untagged leveled logging

--- a/include/dlg/output.h
+++ b/include/dlg/output.h
@@ -100,11 +100,22 @@ DLG_API void dlg_generic_output(dlg_generic_output_handler output, void* data,
 		unsigned int features, const struct dlg_origin* origin, const char* string,
 		const struct dlg_style styles[6]);
 
-
-// Generic output function. Used when user defines a macro DLG_FEATURE_FORMAT
-DLG_API void dlg_generic_output_formatted(dlg_generic_output_handler output, void* data,
-		unsigned int features, const struct dlg_origin* origin, const char* string,
-		const struct dlg_style styles[6], const char* dlg_log_format);
+// Generic output function, using a format string instead of feature flags.
+// Use following conversion characters:
+// %h - output the time in H:M:S format
+// %m - output the time in milliseconds
+// %t - output the full list of tags, comma separated
+// %f - output the function name noted in the origin
+// %o - output the file:line of the origin
+// %s - print the appropriate style escape sequence.
+// %r - print the escape sequence to reset the style.
+// %c - The content of the log/assert
+// %% - print the '%' character
+// Only the above specified conversion characters are valid, the rest are
+// written as it is.
+DLG_API void dlg_generic_outputf(dlg_generic_output_handler output, void* data,
+		const char* format_string, const struct dlg_origin* origin,
+		const char* string, const struct dlg_style styles[6]);
 
 // Generic output function. Used by the default output handler and might be useful
 // for custom output handlers (that don't want to manually format the output).
@@ -115,12 +126,18 @@ DLG_API void dlg_generic_output_formatted(dlg_generic_output_handler output, voi
 DLG_API void dlg_generic_output_stream(FILE* stream, unsigned int features,
 	const struct dlg_origin* origin, const char* string,
 	const struct dlg_style styles[6]);
+DLG_API void dlg_generic_outputf_stream(FILE* stream, const char* format_string,
+	const struct dlg_origin* origin, const char* string,
+	const struct dlg_style styles[6], bool lock_stream);
 
 // Generic output function (see dlg_generic_output) that uses a buffer instead of
 // a stream. buf must at least point to *size bytes. Will set *size to the number
 // of bytes written (capped to the given size), if buf == NULL will set *size
 // to the needed size. The size parameter must not be NULL.
 DLG_API void dlg_generic_output_buf(char* buf, size_t* size, unsigned int features,
+	const struct dlg_origin* origin, const char* string,
+	const struct dlg_style styles[6]);
+DLG_API void dlg_generic_outputf_buf(char* buf, size_t* size, const char* format_string,
 	const struct dlg_origin* origin, const char* string,
 	const struct dlg_style styles[6]);
 
@@ -136,7 +153,7 @@ DLG_API bool dlg_is_tty(FILE* stream);
 DLG_API void dlg_escape_sequence(struct dlg_style style, char buf[12]);
 
 // The reset style escape sequence.
-DLG_API extern const char* dlg_reset_sequence;
+DLG_API extern const char* const dlg_reset_sequence;
 
 // Just returns true without other effect on non-windows systems or if dlg
 // was compiled without the win_console option.

--- a/include/dlg/output.h
+++ b/include/dlg/output.h
@@ -100,6 +100,12 @@ DLG_API void dlg_generic_output(dlg_generic_output_handler output, void* data,
 		unsigned int features, const struct dlg_origin* origin, const char* string,
 		const struct dlg_style styles[6]);
 
+
+// Generic output function. Used when user defines a macro DLG_FEATURE_FORMAT
+DLG_API void dlg_generic_output_formatted(dlg_generic_output_handler output, void* data,
+		unsigned int features, const struct dlg_origin* origin, const char* string,
+		const struct dlg_style styles[6], const char* dlg_log_format);
+
 // Generic output function. Used by the default output handler and might be useful
 // for custom output handlers (that don't want to manually format the output).
 // If stream is NULL uses stdout.

--- a/src/dlg/dlg.c
+++ b/src/dlg/dlg.c
@@ -6,6 +6,9 @@
 #define _POSIX_C_SOURCE 200809L
 #define _WIN32_WINNT 0x0600
 
+// Needed on windows so that we can use sprintf without warning.
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <dlg/output.h>
 #include <dlg/dlg.h>
 #include <wchar.h>


### PR DESCRIPTION
The current version of dlg prints the dlg_features in a specific order i.e. **[time file_line function_name {tags}]**
This pull_request introduces a variable **dlg_log_format** of type **const char*** through which the user can change the order in which these dlg_features are printed.

