### PR TITLE
Fix formatting of microsecond timestamps

### DIFF
--- a/src/dlg/dlg.c
+++ b/src/dlg/dlg.c
@@ -395,7 +395,7 @@ void dlg_generic_outputf(dlg_generic_output_handler output, void* data,
 			}
 			it++;
 		} else if(next == 'm') {
-			output(data, "%d", get_msecs());
+			output(data, "%06d", get_msecs());
 			it++;
 		} else if(next == 't') {
 			bool first_tag = true;


### PR DESCRIPTION
Using the old code, you got something like the following

```
[07:49:06:3784 smooth]    band [3697..3702]: 369 cells
[07:49:07:17364 smooth]    band [3702..3707]: 368 cells
[07:49:07:41477 smooth]    band [3707..3712]: 368 cells
[07:49:07:55083 smooth]    band [3712..3718]: 442 cells
[07:49:07:84382 smooth]    band [3718..3723]: 369 cells
[07:49:07:98022 smooth]    band [3723..3729]: 439 cells
[07:49:07:122158 smooth]    band [3729..3734]: 368 cells
[07:49:07:135764 smooth]    band [3734..3740]: 445 cells
[07:49:07:169301 smooth]    band [3740..3745]: 369 cells
```

which is both badly formatted and misleading, since there are no leading
zeroes in the microsecond field (contrary to the other fields).