### PR TITLE
Make dlg compile on Solaris 10 and 11

### DIFF
--- a/src/dlg/dlg.c
+++ b/src/dlg/dlg.c
@@ -2,7 +2,13 @@
 // Distributed under the Boost Software License, Version 1.0.
 // See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt
 
-#define _XOPEN_SOURCE
+#if defined(__sun)
+	#define _XOPEN_SOURCE 600
+	#define _XPG6
+#else
+	#define _XOPEN_SOURCE
+#endif
+
 #define _POSIX_C_SOURCE 200809L
 #define _WIN32_WINNT 0x0600
 


### PR DESCRIPTION
Without the adjusted settings, gcc 5.5 aborts with

    Compiler or options invalid for pre-UNIX 03 X/Open
    applications and pre-2001 POSIX applications