### PR TITLE
Add `assert_or` macro and assertion text config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ well-documented logging interface in a few hundred lines*):
 
 There are 3 headers:
 
-- [<dlg/dlg.h>](include/dlg/dlg.h) (around 230 loc): Everything you need, no dependencies
+- [<dlg/dlg.h>](include/dlg/dlg.h) (around 280 loc): Everything you need, no dependencies
 - [<dlg/output.h>](include/dlg/output.h) (around 150 loc): Utilities for implementing custom output handlers
 - [<dlg/dlg.hpp>](include/dlg/dlg.hpp) (around 330 loc): Modern C++11 utilities, typesafe formatter
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,14 @@ Up-to-date api
 #define dlg_assertt(tags, expr)
 #define dlg_assertm(expr, ...)
 #define dlg_asserttm(tags, expr, ...)
+
+// If conditions that execute code and potentially log on failure
+#define dlg_assertltm_or(level, tags, expr, code, ...)
+#define dlg_assertlm_or(level, expr, code, ...)
+#define dlg_assertl_or(level, expr, code)
+
+#define dlg_assert_or(expr, code)
+#define dlg_assertm_or(expr, code, ...)
 ```
 
 ## Other

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+2020-11-02
+	- Move documentation from disabled functions to actual implementations,
+	  may be more useful
+	- Add (improved) dlg_assert_or utility macros
+
 2019-12-07
 	- Add dlg_get_handler to allow handler chaining for debugging
 	  [api addition]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,18 @@
-2021-12-22
+2023-04-16 (cumulative)
+	- Add `dlg_assert_or` macro that will execute code in case the 
+	  assertion fails.
+	  Note that this will even happen when dlg is disabled, so suited
+	  for early-outs and defensive coding.
+	- Add `DLG_FAILED_ASSERTION_TEXT(x)`, a wrapper around the failed
+	  expression of an assert. Only ever called when the assertion
+	  has failed, so can be used to add additional handling (e.g.
+	  throwing) in that case for certain build configs. Found to be
+	  useful for static analysis, to silence warnings asserted upon.
 	- Rework how DLG_DISABLE works for api non-macro functions.
 	  The functions are now independent from DLG_DISABLE to prevent
 	  linking issues when DLG_DISABLE is defined
 
-2020-11-02
-	- Move documentation from disabled functions to actual implementations,
-	  may be more useful
-	- Add (improved) dlg_assert_or utility macros
+=== Release of v0.3 ===
 
 2019-12-07
 	- Add dlg_get_handler to allow handler chaining for debugging

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+2021-12-22
+	- Rework how DLG_DISABLE works for api non-macro functions.
+	  The functions are now independent from DLG_DISABLE to prevent
+	  linking issues when DLG_DISABLE is defined
+
 2020-11-02
 	- Move documentation from disabled functions to actual implementations,
 	  may be more useful

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -131,88 +131,12 @@ struct dlg_origin {
 // Type of the output handler, see dlg_set_handler.
 typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, void* data);
 
-#ifdef DLG_DISABLE
+#ifndef DLG_DISABLE
 	// Tagged/Untagged logging with variable level
 	// Tags must always be in the format `("tag1", "tag2")` (including brackets)
-	#define dlg_log(level, ...)
-	#define dlg_logt(level, tags, ...)
-
-	// Dynamic level assert macros in various versions for additional arguments
-	#define dlg_assertl(level, expr) // assert without tags/message
-	#define dlg_assertlt(level, tags, expr) // assert with tags
-	#define dlg_assertlm(level, expr, ...) // assert with message
-	#define dlg_assertltm(level, tags, expr, ...) // assert with tags & message
-
-	// assert as abvoe, additionally execute 'code' on failure
-	#define dlg_assertltm_or(level, tags, expr, code, ...)
-	#define dlg_assertlm_or(level, expr, code, ...)
-	#define dlg_assertl_or(level, expr, code)
-
-	// Sets the handler that is responsible for formatting and outputting log calls.
-	// This function is not thread safe and the handler is set globally.
-	// The handler itself must not change dlg tags or call a dlg macro (if it
-	// does so, the provided string or tags array in 'origin' might get invalid).
-	// The handler can also be used for various other things such as dealing
-	// with failed assertions or filtering calls based on the passed tags.
-	// The default handler is dlg_default_output (see its doc for more info).
-	// If using c++ make sure the registered handler cannot throw e.g. by
-	// wrapping everything into a try-catch blog.
-	inline void dlg_set_handler(dlg_handler handler, void* data) {
-		(void) handler;
-		(void) data;
-	}
-
-	// Returns the currently active dlg handler and sets `data` to
-	// its user data pointer. `data` must not be NULL.
-	// Useful to create handler chains.
-	// This function is not threadsafe, i.e. retrieving the handler while
-	// changing it from another thread is unsafe.
-	// See `dlg_set_handler`.
-	inline dlg_handler dlg_get_handler(void** data) {
-		*data = NULL;
-		return NULL;
-	}
-
-	// The default output handler.
-	// Only use this to reset the output handler, prefer to use
-	// dlg_generic_output (from output.h) which this function simply calls.
-	// It also flushes the stream used and correctly outputs even from multiple threads.
-	inline void dlg_default_output(const struct dlg_origin* o, const char* str, void* data) {
-		(void) o;
-		(void) str;
-		(void) data;
-	}
-
-	// Adds the given tag associated with the given function to the thread specific list.
-	// If func is not NULL the tag will only applied to calls from the same function.
-	// Remove the tag again calling dlg_remove_tag (with exactly the same pointers!).
-	// Does not check if the tag is already present.
-	inline void dlg_add_tag(const char* tag, const char* func) {
-		(void) tag;
-		(void) func;
-	}
-
-	// Removes a tag added with dlg_add_tag (has no effect for tags no present).
-	// The pointers must be exactly the same pointers that were supplied to dlg_add_tag,
-	// this function will not check using strcmp. When the same tag/func combination
-	// is added multiple times, this function remove exactly one candidate, it is
-	// undefined which. Returns whether a tag was found (and removed).
-	inline bool dlg_remove_tag(const char* tag, const char* func) {
-		(void) tag;
-		(void) func;
-		return true;
-	}
-
-	// Returns the thread-specific buffer and its size for dlg.
-	// The buffer should only be used by formatting functions.
-	// The buffer can be reallocated and the size changed, just make sure
-	// to update both values correctly.
-	inline char** dlg_thread_buffer(size_t** size) {
-		(void) size;
-		return NULL;
-	}
-
-#else // DLG_DISABLE
+	// Example usages:
+	//   dlg_log(dlg_level_warning, "test 1")
+	//   dlg_logt(("tag1, "tag2"), dlg_level_debug, "test %d", 2)
 	#define dlg_log(level, ...) if(level >= DLG_LOG_LEVEL) \
 		dlg__do_log(level, DLG_CREATE_TAGS(NULL), DLG_FILE, __LINE__, __func__,  \
 		DLG_FMT_FUNC(__VA_ARGS__), NULL)
@@ -220,6 +144,12 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__, __func__, \
 		DLG_FMT_FUNC(__VA_ARGS__), NULL)
 
+	// Dynamic level assert macros in various versions for additional arguments
+	// Example usages:
+	//   dlg_assertl(dlg_level_warning, data != nullptr);
+	//   dlg_assertlt(("tag1, "tag2"), dlg_level_trace, data != nullptr);
+	//   dlg_asserttlm(("tag1), dlg_level_warning, data != nullptr, "Data must not be null");
+	//   dlg_assertlm(dlg_level_error, data != nullptr, "Data must not be null");
 	#define dlg_assertl(level, expr) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
 		dlg__do_log(level, DLG_CREATE_TAGS(NULL), DLG_FILE, __LINE__, __func__, NULL, #expr)
 	#define dlg_assertlt(level, tags, expr) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
@@ -231,29 +161,76 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 		__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr)
 
-	// assert with tags & message, execute 'code' on failure
+	// If (expr) does not hold, always executes 'code' (no matter what
+	// DLG_ASSERT_LEVEL is or if dlg is disabled or not).
+	// When dlg is enabled and the level is greater or equal to DLG_ASSERT_LEVEL,
+	// logs the fails assertion.
+	// Example usages:
+	//   dlg_assertl_or(dlg_level_warn, data != nullptr, return);
+	//   dlg_assertlm_or(dlg_level_fatal, data != nullptr, return, "Data must not be null");
 	#define dlg_assertltm_or(level, tags, expr, code, ...) \
-		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
-			dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
-				__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
+		if(!(expr)) {\
+			if(level >= DLG_ASSERT_LEVEL) \
+				dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
+					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
-		} while(false)
+		} (void) NULL
 	#define dlg_assertlm_or(level, expr, code, ...) \
-		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
-			dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
+		if(!(expr)) {\
+			if(level >= DLG_ASSERT_LEVEL) \
+				dlg__do_log(level, NULL, DLG_FILE, __LINE__,  \
+					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
-		} while(false)
+		} (void) NULL
 	#define dlg_assertl_or(level, expr, code) \
-		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
-			dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
+		if(!(expr)) {\
+			if(level >= DLG_ASSERT_LEVEL) {\
+				dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
 			code; \
-		} while(false)
+		} (void) NULL
 
+	// Sets the handler that is responsible for formatting and outputting log calls.
+	// This function is not thread safe and the handler is set globally.
+	// The handler itself must not change dlg tags or call a dlg macro (if it
+	// does so, the provided string or tags array in 'origin' might get invalid).
+	// The handler can also be used for various other things such as dealing
+	// with failed assertions or filtering calls based on the passed tags.
+	// The default handler is dlg_default_output (see its doc for more info).
+	// If using c++ make sure the registered handler cannot throw e.g. by
+	// wrapping everything into a try-catch blog.
 	DLG_API void dlg_set_handler(dlg_handler handler, void* data);
+
+	// Returns the currently active dlg handler and sets `data` to
+	// its user data pointer. `data` must not be NULL.
+	// Useful to create handler chains.
+	// This function is not threadsafe, i.e. retrieving the handler while
+	// changing it from another thread is unsafe.
+	// See `dlg_set_handler`.
 	DLG_API dlg_handler dlg_get_handler(void** data);
+
+	// The default output handler.
+	// Only use this to reset the output handler, prefer to use
+	// dlg_generic_output (from output.h) which this function simply calls.
+	// It also flushes the stream used and correctly outputs even from multiple threads.
 	DLG_API void dlg_default_output(const struct dlg_origin*, const char* string, void*);
+
+	// Adds the given tag associated with the given function to the thread specific list.
+	// If func is not NULL the tag will only applied to calls from the same function.
+	// Remove the tag again calling dlg_remove_tag (with exactly the same pointers!).
+	// Does not check if the tag is already present.
 	DLG_API void dlg_add_tag(const char* tag, const char* func);
+
+	// Removes a tag added with dlg_add_tag (has no effect for tags no present).
+	// The pointers must be exactly the same pointers that were supplied to dlg_add_tag,
+	// this function will not check using strcmp. When the same tag/func combination
+	// is added multiple times, this function remove exactly one candidate, it is
+	// undefined which. Returns whether a tag was found (and removed).
 	DLG_API bool dlg_remove_tag(const char* tag, const char* func);
+
+	// Returns the thread-specific buffer and its size for dlg.
+	// The buffer should only be used by formatting functions.
+	// The buffer can be reallocated and the size changed, just make sure
+	// to update both values correctly.
 	DLG_API char** dlg_thread_buffer(size_t** size);
 
 	// - Private interface: not part of the abi/api but needed in macros -
@@ -262,6 +239,52 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	DLG_API void dlg__do_log(enum dlg_level lvl, const char* const*, const char*, int,
 		const char*, const char*, const char*);
 	DLG_API const char* dlg__strip_root_path(const char* file, const char* base);
+
+#else // DLG_DISABLE
+
+	#define dlg_log(level, ...)
+	#define dlg_logt(level, tags, ...)
+
+	#define dlg_assertl(level, expr) // assert without tags/message
+	#define dlg_assertlt(level, tags, expr) // assert with tags
+	#define dlg_assertlm(level, expr, ...) // assert with message
+	#define dlg_assertltm(level, tags, expr, ...) // assert with tags & message
+
+	#define dlg_assertltm_or(level, tags, expr, code, ...) if(!expr) code; (void) NULL
+	#define dlg_assertlm_or(level, expr, code, ...) if(!expr) code; (void) NULL
+	#define dlg_assertl_or(level, expr, code) if(!expr) code; (void) NULL
+
+	inline void dlg_set_handler(dlg_handler handler, void* data) {
+		(void) handler;
+		(void) data;
+	}
+
+	inline dlg_handler dlg_get_handler(void** data) {
+		*data = NULL;
+		return NULL;
+	}
+
+	inline void dlg_default_output(const struct dlg_origin* o, const char* str, void* data) {
+		(void) o;
+		(void) str;
+		(void) data;
+	}
+
+	inline void dlg_add_tag(const char* tag, const char* func) {
+		(void) tag;
+		(void) func;
+	}
+
+	inline bool dlg_remove_tag(const char* tag, const char* func) {
+		(void) tag;
+		(void) func;
+		return true;
+	}
+
+	inline char** dlg_thread_buffer(size_t** size) {
+		(void) size;
+		return NULL;
+	}
 #endif // DLG_DISABLE
 
 // Untagged leveled logging

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -184,7 +184,7 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		} (void) NULL
 	#define dlg_assertl_or(level, expr, code) \
 		if(!(expr)) {\
-			if(level >= DLG_ASSERT_LEVEL) {\
+			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
 			code; \
 		} (void) NULL

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -169,22 +169,19 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	//   dlg_assertl_or(dlg_level_warn, data != nullptr, return);
 	//   dlg_assertlm_or(dlg_level_fatal, data != nullptr, return, "Data must not be null");
 	//   dlg_assert_or(data != nullptr, logError(); return false);
-	#define dlg_assertltm_or(level, tags, expr, code, ...) do {\
-		if(!(expr)) {\
+	#define dlg_assertltm_or(level, tags, expr, code, ...) do if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
 		} while(false)
-	#define dlg_assertlm_or(level, expr, code, ...) do {\
-		if(!(expr)) {\
+	#define dlg_assertlm_or(level, expr, code, ...) do if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, NULL, DLG_FILE, __LINE__,  \
 					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
 		} while(false)
-	#define dlg_assertl_or(level, expr, code) do {\
-		if(!(expr)) {\
+	#define dlg_assertl_or(level, expr, code) do if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
 			code; \

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -161,11 +161,11 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 		__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr)
 
-	#define dlg__assert_or(level, tags, expr, code, msg) do if(!(expr)) {\
+	#define dlg__assert_or(level, tags, expr, code, msg) if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, tags, DLG_FILE, __LINE__, __func__, msg, #expr); \
 			code; \
-		} while(false)
+		} (void) NULL
 
 
 	// Sets the handler that is responsible for formatting and outputting log calls.
@@ -229,7 +229,7 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	#define dlg_assertlm(level, expr, ...) // assert with message
 	#define dlg_assertltm(level, tags, expr, ...) // assert with tags & message
 
-	#define dlg__assert_or(level, tags, expr, code, msg) do if(!(expr)) { code; } while(false)
+	#define dlg__assert_or(level, tags, expr, code, msg) if(!(expr)) { code; } (void) NULL
 
 	inline void dlg_set_handler(dlg_handler handler, void* data) {
 		(void) handler;

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -161,33 +161,34 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 		__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr)
 
-	// If (expr) does not hold, always executes 'code' (no matter what
+	// If (expr) does not evaluate to true, always executes 'code' (no matter what
 	// DLG_ASSERT_LEVEL is or if dlg is disabled or not).
 	// When dlg is enabled and the level is greater or equal to DLG_ASSERT_LEVEL,
-	// logs the fails assertion.
+	// logs the failed assertion.
 	// Example usages:
 	//   dlg_assertl_or(dlg_level_warn, data != nullptr, return);
 	//   dlg_assertlm_or(dlg_level_fatal, data != nullptr, return, "Data must not be null");
-	#define dlg_assertltm_or(level, tags, expr, code, ...) \
+	//   dlg_assert_or(data != nullptr, logError(); return false);
+	#define dlg_assertltm_or(level, tags, expr, code, ...) do {\
 		if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
-		} (void) NULL
-	#define dlg_assertlm_or(level, expr, code, ...) \
+		} while(false)
+	#define dlg_assertlm_or(level, expr, code, ...) do {\
 		if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, NULL, DLG_FILE, __LINE__,  \
 					__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
 			code; \
-		} (void) NULL
-	#define dlg_assertl_or(level, expr, code) \
+		} while(false)
+	#define dlg_assertl_or(level, expr, code) do {\
 		if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
 				dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
 			code; \
-		} (void) NULL
+		} while(false)
 
 	// Sets the handler that is responsible for formatting and outputting log calls.
 	// This function is not thread safe and the handler is set globally.
@@ -250,9 +251,9 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	#define dlg_assertlm(level, expr, ...) // assert with message
 	#define dlg_assertltm(level, tags, expr, ...) // assert with tags & message
 
-	#define dlg_assertltm_or(level, tags, expr, code, ...) if(!expr) code; (void) NULL
-	#define dlg_assertlm_or(level, expr, code, ...) if(!expr) code; (void) NULL
-	#define dlg_assertl_or(level, expr, code) if(!expr) code; (void) NULL
+	#define dlg_assertltm_or(level, tags, expr, code, ...) if(!expr) { code; } (void) NULL
+	#define dlg_assertlm_or(level, expr, code, ...) if(!expr) { code; } (void) NULL
+	#define dlg_assertl_or(level, expr, code) if(!expr) { code; } (void) NULL
 
 	inline void dlg_set_handler(dlg_handler handler, void* data) {
 		(void) handler;

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -143,6 +143,11 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	#define dlg_assertlm(level, expr, ...) // assert with message
 	#define dlg_assertltm(level, tags, expr, ...) // assert with tags & message
 
+	// assert as abvoe, additionally execute 'code' on failure
+	#define dlg_assertltm_or(level, tags, expr, code, ...)
+	#define dlg_assertlm_or(level, expr, code, ...)
+	#define dlg_assertl_or(level, expr, code)
+
 	// Sets the handler that is responsible for formatting and outputting log calls.
 	// This function is not thread safe and the handler is set globally.
 	// The handler itself must not change dlg tags or call a dlg macro (if it
@@ -226,6 +231,24 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
 		__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr)
 
+	// assert with tags & message, execute 'code' on failure
+	#define dlg_assertltm_or(level, tags, expr, code, ...) \
+		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
+			dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
+				__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
+			code; \
+		} while(false)
+	#define dlg_assertlm_or(level, expr, code, ...) \
+		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
+			dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, DLG_FMT_FUNC(__VA_ARGS__), #expr); \
+			code; \
+		} while(false)
+	#define dlg_assertl_or(level, expr, code) \
+		do if(level >= DLG_ASSERT_LEVEL && !(expr)) {\
+			dlg__do_log(level, NULL, DLG_FILE, __LINE__, __func__, NULL, #expr); \
+			code; \
+		} while(false)
+
 	DLG_API void dlg_set_handler(dlg_handler handler, void* data);
 	DLG_API dlg_handler dlg_get_handler(void** data);
 	DLG_API void dlg_default_output(const struct dlg_origin*, const char* string, void*);
@@ -262,6 +285,9 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 #define dlg_assertt(tags, expr) dlg_assertlt(DLG_DEFAULT_ASSERT, tags, expr)
 #define dlg_assertm(expr, ...) dlg_assertlm(DLG_DEFAULT_ASSERT, expr, __VA_ARGS__)
 #define dlg_asserttm(tags, expr, ...) dlg_assertltm(DLG_DEFAULT_ASSERT, tags, expr, __VA_ARGS__)
+
+#define dlg_assert_or(expr, code) dlg_assertl_or(DLG_DEFAULT_ASSERT, expr, code)
+#define dlg_assertm_or(expr, code, ...) dlg_assertlm_or(DLG_DEFAULT_ASSERT, expr, code, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/include/dlg/dlg.h
+++ b/include/dlg/dlg.h
@@ -85,6 +85,13 @@
 	#endif
 #endif
 
+// This macro is used when an assertion fails. It gets the source expression
+// and can return an alternative (that must stay alive).
+// Mainly useful to execute something on failed assertion.
+#ifndef DLG_FAILED_ASSERTION_TEXT
+	#define DLG_FAILED_ASSERTION_TEXT(x) x
+#endif
+
 // - utility -
 // two methods needed since cplusplus does not support compound literals
 // and c does not support uniform initialization/initializer lists
@@ -151,19 +158,22 @@ typedef void(*dlg_handler)(const struct dlg_origin* origin, const char* string, 
 	//   dlg_asserttlm(("tag1), dlg_level_warning, data != nullptr, "Data must not be null");
 	//   dlg_assertlm(dlg_level_error, data != nullptr, "Data must not be null");
 	#define dlg_assertl(level, expr) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
-		dlg__do_log(level, DLG_CREATE_TAGS(NULL), DLG_FILE, __LINE__, __func__, NULL, #expr)
+		dlg__do_log(level, DLG_CREATE_TAGS(NULL), DLG_FILE, __LINE__, __func__, NULL, \
+			DLG_FAILED_ASSERTION_TEXT(#expr))
 	#define dlg_assertlt(level, tags, expr) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
-		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__, __func__, NULL, #expr)
+		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__, __func__, NULL, \
+			DLG_FAILED_ASSERTION_TEXT(#expr))
 	#define dlg_assertlm(level, expr, ...) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
 		dlg__do_log(level, DLG_CREATE_TAGS(NULL), DLG_FILE, __LINE__, __func__,  \
-		DLG_FMT_FUNC(__VA_ARGS__), #expr)
+			DLG_FMT_FUNC(__VA_ARGS__), DLG_FAILED_ASSERTION_TEXT(#expr))
 	#define dlg_assertltm(level, tags, expr, ...) if(level >= DLG_ASSERT_LEVEL && !(expr)) \
 		dlg__do_log(level, DLG_CREATE_TAGS tags, DLG_FILE, __LINE__,  \
-		__func__, DLG_FMT_FUNC(__VA_ARGS__), #expr)
+			__func__, DLG_FMT_FUNC(__VA_ARGS__), DLG_FAILED_ASSERTION_TEXT(#expr))
 
 	#define dlg__assert_or(level, tags, expr, code, msg) if(!(expr)) {\
 			if(level >= DLG_ASSERT_LEVEL) \
-				dlg__do_log(level, tags, DLG_FILE, __LINE__, __func__, msg, #expr); \
+				dlg__do_log(level, tags, DLG_FILE, __LINE__, __func__, msg, \
+					DLG_FAILED_ASSERTION_TEXT(#expr)); \
 			code; \
 		} (void) NULL
 

--- a/include/dlg/dlg.hpp
+++ b/include/dlg/dlg.hpp
@@ -13,6 +13,8 @@
 // TODO: override the default (via undef) if a dlg.h was included before this file?
 #ifndef DLG_FMT_FUNC
 	#define DLG_FMT_FUNC ::dlg::detail::tlformat
+#elif defined(INC_DLG_DLG_H_)
+	#warning "dlg.h was included before dlg.hpp, not overriding DLG_FMT_FUNC"
 #endif
 
 #include <dlg/dlg.h>


### PR DESCRIPTION
From changelog:

- Add `dlg_assert_or` macro that will execute code in case the 
	  assertion fails.
	  Note that this will even happen when dlg is disabled, so suited
	  for early-outs and defensive coding.
- Add `DLG_FAILED_ASSERTION_TEXT(x)`, a wrapper around the failed
	expression of an assert. Only ever called when the assertion
	has failed, so can be used to add additional handling (e.g.
	throwing) in that case for certain build configs. Found to be
	useful for static analysis, to silence warnings asserted upon.
- Rework how DLG_DISABLE works for api non-macro functions.
	The functions are now independent from DLG_DISABLE to prevent
	linking issues when DLG_DISABLE is defined